### PR TITLE
Submission 40230259 – A01

### DIFF
--- a/assignments/submissions/40230259/01/python/matrizes_tipos.py
+++ b/assignments/submissions/40230259/01/python/matrizes_tipos.py
@@ -1,0 +1,159 @@
+import numpy as np
+
+# Task 1
+print("\nTarefa 1")
+
+# Matriz de zeros (3x4)
+zero_matrix = np.zeros((3, 4))
+
+# Matriz identidade (4x4)
+identity_matrix = np.eye(4)
+
+# Matriz diagonal (3x3) com os valores 2, 5 e -1
+diagonal_matrix = np.diag([2, 5, -1])
+
+# Matriz triangular superior (3x3)
+upper_triangular = np.array([
+    [3, 1, 6],
+    [0, 2, 9],
+    [0, 0, 9]
+], dtype=float)
+
+# Matriz triangular inferior (3x3)
+lower_triangular = np.array([
+    [3, 0, 0],
+    [6, 2, 0],
+    [7, 7, 9]
+], dtype=float)
+
+
+# Matriz simétrica, a partir da fórmula M + M^T
+M = np.array ([
+    [3, 1, 6],    
+    [6, 2, 9],
+    [7, 7, 9]
+], dtype=float)
+
+symmetric_matrix = M + M.T
+
+
+print("Matriz de Zeros:")
+print(zero_matrix)
+
+print("\nMatriz Identidade:")
+print(identity_matrix)
+
+print("\nMatriz Diagonal:")
+print(diagonal_matrix)
+
+print("\nMatriz Triangular Superior:")
+print(upper_triangular)
+
+print("\nMatriz Triangular Inferior:")
+print(lower_triangular)
+
+print("\nMatriz Simétrica (M + M^T):")
+print(symmetric_matrix)
+
+
+
+# Task 2
+print("\nTarefa 2")
+
+print("\nMatriz de Zeros:")
+print(f"Dimensões: {zero_matrix.shape[0]} x  {zero_matrix.shape[1]}")
+print(f"a23 = {zero_matrix[1, 2]}")
+
+print("\nMatriz Identidade:")
+print(f"Dimensões: {identity_matrix.shape[0]} x  {identity_matrix.shape[1]}")
+print(f"a23 = {identity_matrix[1, 2]}")
+
+print("\nMatriz Diagonal:")
+print(f"Dimensões: {diagonal_matrix.shape[0]} x  {diagonal_matrix.shape[1]}")
+print(f"a23 = {diagonal_matrix[1, 2]}")
+
+print("\nMatriz Triangular Superior:")
+print(f"Dimensões: {upper_triangular.shape[0]} x  {upper_triangular.shape[1]}")
+print(f"a23 = {upper_triangular[1, 2]}")
+
+print("\nMatriz Triangular Inferior:")
+print(f"Dimensões: {lower_triangular.shape[0]} x  {lower_triangular.shape[1]}")
+print(f"a23 = {lower_triangular[1, 2]}")
+
+print("\nMatriz Simétrica:")
+print(f"Dimensões: {symmetric_matrix.shape[0]} x  {symmetric_matrix.shape[1]}")
+print(f"a23 = {symmetric_matrix[1, 2]}")
+
+
+
+# Task 3
+print("\nTarefa 3")
+
+def classificar_matriz(A):
+    classificacoes = []
+    linhas, colunas = A.shape
+
+    # Quadrada e Retangular
+    if linhas == colunas:
+        classificacoes.append("quadrada")
+    else:
+        classificacoes.append("retangular")
+
+    # Nula
+    if np.all(A == 0):
+        classificacoes.append("nula")
+
+    # Identidade
+    if linhas == colunas and np.allclose(A, np.eye(linhas)):
+        classificacoes.append("identidade")
+
+    # Diagonal
+    if linhas == colunas and np.allclose(A, np.diag(np.diag(A))):
+        classificacoes.append("diagonal")
+
+    # Triangular Superior
+    if linhas == colunas and np.allclose(A, np.triu(A)):
+        classificacoes.append("triangular_superior")    
+
+    # Triangular Inferior
+    if linhas == colunas and np.allclose(A, np.tril(A)):
+        classificacoes.append("triangular_inferior")    
+
+    return classificacoes
+
+print(f"Matriz de Zeros: {classificar_matriz(zero_matrix)}")
+
+print(f"Matriz Identidade: {classificar_matriz(identity_matrix)}")
+
+print(f"Matriz Diagonal: {classificar_matriz(diagonal_matrix)}")
+
+print(f"Matriz Triangular Superior: {classificar_matriz(upper_triangular)}")
+
+print(f"Matriz Triangular Inferior: {classificar_matriz(lower_triangular)}")
+
+print(f"Matriz Simétrica (M + M^T): {classificar_matriz(symmetric_matrix)}")
+
+
+
+# Task 4
+print("\nTarefa 4")
+
+# Soma de matrizes incompatíveis
+A = np.ones((6, 2))
+B = np.ones((3, 5))
+
+try:
+    resultado = A + B
+except ValueError as erro:
+    print("Erro ao somar matrizes incompatíveis:")
+    print(erro)
+
+# Multiplicação de matrizes incompatíveis
+    C = np.ones((2, 7))
+    D = np.ones((4, 3))
+
+try:
+    resultado = C @ D
+except ValueError as erro:
+    print("\nErro ao multiplicar matrizes incompatíveis:")
+    print(erro)

--- a/assignments/submissions/40230259/01/reflexao.md
+++ b/assignments/submissions/40230259/01/reflexao.md
@@ -1,0 +1,11 @@
+Neste trabalho, explorei diferentes tipos de matrizes.
+
+A matriz identidade tem sempre 1 na diagonal principal e 0 em todas as outras posições. Por causa disso, é uma matriz diagonal, já que todos os números fora da diagonal são iguais a zero. 
+
+Também é simétrica, porque se trocar linhas por colunas continua igual à matriz original.
+
+Como não existem valores acima nem abaixo da diagonal, também se encaixa como matriz triangular superior e inferior.
+
+Isto mostra que estas classificações de matrizes não são conjuntos totalmente separados, e que uma matriz pode pertencer a várias ao mesmo tempo.
+
+Ao usar Python, com a ajuda de NumPy, foi simples criar e testar estas matrizes com funções prontas como np.eye e np.diag.


### PR DESCRIPTION
## Submission Metadata
- Student number: 40230259
- Assignment code (`A01`): 
- Language track (`python`): 
- Submission folder path (`assignments/submissions/40230259/01/`): 

## Student Submission Checklist
- [x] This PR targets `develop`
- [x] Source branch follows `<student_number>-A<nn>` (example: `40250001-A01`)
- [x] PR title follows `Submission <student_number> --- A<nn>`
- [x] Assignment code is between `A01` and `A06`
- [x] All changed files are inside `assignments/submissions/<student>/<nn>/`
- [x] `README.md` exists in the submission folder
- [x] `reflexao.md` exists in the submission folder
- [x] Exactly one language track is present (`python/` or `javascript/`, not both)

## Notes (optional)
- 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds A01 submission for student 40230259. Includes a `numpy` script that builds and classifies matrices and a short reflection, all under `assignments/submissions/40230259/01/`.

- **New Features**
  - Added `python/matrizes_tipos.py`:
    - Creates zeros, identity, diagonal, upper/lower triangular, and symmetric matrices.
    - Prints dimensions and `a23` values; classifies matrices (nula, identidade, diagonal, triangular).
    - Shows errors for incompatible sum/multiplication with try/except.
  - Added `README.md` (placeholder) and `reflexao.md` describing identity matrix properties and use of `numpy`.

<sup>Written for commit 8263bc223e520fe810888328b754830c0acd00c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/linear-algebra-with-python/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

