### PR TITLE
Submission 40250178 - A04

### DIFF
--- a/assignments/submissions/40250178/04/README.md
+++ b/assignments/submissions/40250178/04/README.md
@@ -1,0 +1,24 @@
+# Assignment 04 — Sistemas Lineares: Gauss e Classificação
+
+**Aluno:** 40250178  
+**Linguagem:** JavaScript com math.js
+
+## Como correr
+
+```bash
+npm install mathjs
+node javascript/sistemas_lineares.js
+```
+
+Para as visualizações abrir `javascript/sistemas_lineares.html` no browser.
+
+## O que foi feito
+
+- T1: escalonar() com pivotamento parcial + substituicao_retroativa(), resolução do sistema dado
+- T2: sistema SPI — echelon revela variável livre, 3 soluções particulares
+- T3: sistema SI — echelon revela contradição 0 = valor
+- T4: classificar_sistema() via análise de rank (Rouché-Capelli), testado em 5 sistemas
+- T5: solução paramétrica explícita com verificação
+- T6: comparação com math.lusolve e teste com sistema singular
+- T7: visualizações 2D (3 casos) e 3D (3 planos num ponto) no ficheiro HTML
+- T8: reflexao.md

--- a/assignments/submissions/40250178/04/javascript/sistemas_lineares.html
+++ b/assignments/submissions/40250178/04/javascript/sistemas_lineares.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <title>A04 - Sistemas Lineares</title>
+  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+  <style>
+    body { font-family: sans-serif; margin: 20px; background: #f0f0f0; }
+    h2 { color: #222; }
+    .chart { background: white; padding: 15px; margin-bottom: 30px; border-radius: 8px; }
+  </style>
+</head>
+<body>
+  <h2>A04 — Sistemas Lineares: Gauss e Classificação</h2>
+
+  <div id="retas2d" class="chart"></div>
+  <div id="planos3d" class="chart"></div>
+
+  <script>
+    // ─── T7a: 3 sistemas 2D — único, infinito, impossível ────────────────────
+    const t = Array.from({length: 200}, (_, i) => -5 + i * 0.05);
+
+    // Sistema SPD: x + y = 2, x - y = 0 → interseção em (1,1)
+    const r1a = { x: t, y: t.map(ti => 2 - ti), mode:'lines', name:'x+y=2', line:{color:'blue'}, xaxis:'x', yaxis:'y' };
+    const r1b = { x: t, y: t.map(ti => ti),      mode:'lines', name:'x-y=0', line:{color:'cyan'}, xaxis:'x', yaxis:'y' };
+
+    // Sistema SPI: x + y = 2, 2x + 2y = 4 → mesma reta
+    const r2a = { x: t, y: t.map(ti => 2 - ti),  mode:'lines', name:'x+y=2', line:{color:'red'}, xaxis:'x2', yaxis:'y2' };
+    const r2b = { x: t, y: t.map(ti => 2 - ti),  mode:'lines', name:'2x+2y=4', line:{color:'orange', dash:'dot', width:4}, xaxis:'x2', yaxis:'y2' };
+
+    // Sistema SI: x + y = 2, x + y = 4 → paralelas
+    const r3a = { x: t, y: t.map(ti => 2 - ti), mode:'lines', name:'x+y=2', line:{color:'green'}, xaxis:'x3', yaxis:'y3' };
+    const r3b = { x: t, y: t.map(ti => 4 - ti), mode:'lines', name:'x+y=4', line:{color:'lime'}, xaxis:'x3', yaxis:'y3' };
+
+    // ponto de interseção do SPD
+    const inter = { x:[1], y:[1], mode:'markers', name:'Solução única', marker:{size:10, color:'red'}, xaxis:'x', yaxis:'y' };
+
+    Plotly.newPlot('retas2d', [r1a, r1b, inter, r2a, r2b, r3a, r3b], {
+      title: 'Sistemas 2D: único (SPD), infinito (SPI), impossível (SI)',
+      grid: { rows:1, columns:3, pattern:'independent' },
+      xaxis:  { range:[-3,5], title:'SPD — solução única' },   yaxis:  { range:[-1,5] },
+      xaxis2: { range:[-3,5], title:'SPI — infinitas soluções' }, yaxis2: { range:[-1,5] },
+      xaxis3: { range:[-3,5], title:'SI — impossível' },         yaxis3: { range:[-1,5] },
+      height: 420
+    });
+
+    // ─── T7b: 3 planos intersectando num ponto ────────────────────────────────
+    // Plano 1: x = 1,  Plano 2: y = 1,  Plano 3: z = 1
+    const vals = Array.from({length:8}, (_, i) => -2 + i * 0.57);
+
+    function flatPlane(fixedAxis, val) {
+      if (fixedAxis === 'x') {
+        return { type:'surface', x: vals.map(()=>val), y: [vals, vals, vals, vals, vals, vals, vals, vals], z: vals.map(v => vals), opacity:0.4, showscale:false };
+      }
+      if (fixedAxis === 'y') {
+        return { type:'surface', x: [vals, vals, vals, vals, vals, vals, vals, vals], y: vals.map(()=>[val,val,val,val,val,val,val,val]), z: vals.map(v => vals), opacity:0.4, showscale:false };
+      }
+      // z
+      return { type:'surface', x: [vals,vals,vals,vals,vals,vals,vals,vals], y: vals.map(v=>vals), z: vals.map(()=>vals.map(()=>val)), opacity:0.4, showscale:false };
+    }
+
+    // versão simplificada: 3 planos usando meshgrid manual
+    const grid = Array.from({length:8}, (_, i) => -2 + i * 0.57);
+    const Z0 = grid.map(() => grid.map(() => 0));
+    const Z1 = grid.map(() => grid.map(() => 1));
+
+    const plano1 = { // z = 1
+      type:'surface', x:grid, y:grid, z:Z1,
+      opacity:0.35, colorscale:[[0,'#3498db'],[1,'#3498db']], showscale:false, name:'z=1'
+    };
+    const plano2 = { // x = 1 (surface via scatter3d aproximado)
+      type:'mesh3d',
+      x:[1,1,1,1], y:[-2,-2,2,2], z:[-2,2,-2,2],
+      i:[0,0], j:[1,2], k:[2,3],
+      opacity:0.35, color:'#e74c3c', name:'x=1'
+    };
+    const plano3 = {
+      type:'mesh3d',
+      x:[-2,-2,2,2], y:[1,1,1,1], z:[-2,2,-2,2],
+      i:[0,0], j:[1,2], k:[2,3],
+      opacity:0.35, color:'#2ecc71', name:'y=1'
+    };
+    const ponto = {
+      type:'scatter3d', mode:'markers',
+      x:[1], y:[1], z:[1],
+      marker:{ size:10, color:'orange' }, name:'Solução (1,1,1)'
+    };
+
+    Plotly.newPlot('planos3d', [plano1, plano2, plano3, ponto], {
+      title: 'Três planos intersectando num ponto (1,1,1)',
+      scene: { xaxis:{title:'X'}, yaxis:{title:'Y'}, zaxis:{title:'Z'} },
+      height: 500
+    });
+  </script>
+</body>
+</html>

--- a/assignments/submissions/40250178/04/javascript/sistemas_lineares.js
+++ b/assignments/submissions/40250178/04/javascript/sistemas_lineares.js
@@ -1,0 +1,179 @@
+const math = require('mathjs');
+
+const eps = 1e-10;
+
+// ─── T1: Eliminação de Gauss com pivotamento parcial + substituição retroativa ─
+
+function escalonar(Ab) {
+  const m = Ab.map(row => [...row]);
+  const rows = m.length;
+  const cols = m[0].length;
+  const log = [];
+
+  for (let col = 0, row = 0; col < cols - 1 && row < rows; col++) {
+    // pivotamento parcial
+    let maxRow = row;
+    for (let i = row + 1; i < rows; i++) {
+      if (Math.abs(m[i][col]) > Math.abs(m[maxRow][col])) maxRow = i;
+    }
+    if (Math.abs(m[maxRow][col]) < eps) continue;
+
+    if (maxRow !== row) {
+      [m[row], m[maxRow]] = [m[maxRow], m[row]];
+      log.push(`Troca linha ${row+1} <-> linha ${maxRow+1}`);
+    }
+
+    for (let i = row + 1; i < rows; i++) {
+      const fator = m[i][col] / m[row][col];
+      if (Math.abs(fator) < eps) continue;
+      for (let j = col; j < cols; j++) m[i][j] -= fator * m[row][j];
+      log.push(`L${i+1} = L${i+1} - (${fator.toFixed(4)}) * L${row+1}`);
+    }
+    row++;
+  }
+  return { echelon: m, log };
+}
+
+function substituicao_retroativa(echelon) {
+  const rows = echelon.length;
+  const cols = echelon[0].length;
+  const n = cols - 1;
+  const x = new Array(n).fill(0);
+
+  for (let i = rows - 1; i >= 0; i--) {
+    // encontrar pivot
+    let pivCol = -1;
+    for (let j = 0; j < n; j++) {
+      if (Math.abs(echelon[i][j]) > eps) { pivCol = j; break; }
+    }
+    if (pivCol === -1) continue;
+    let sum = echelon[i][n];
+    for (let j = pivCol + 1; j < n; j++) sum -= echelon[i][j] * x[j];
+    x[pivCol] = sum / echelon[i][pivCol];
+  }
+  return x;
+}
+
+console.log('─── T1: Sistema 2x + y - z = 8, -3x - y + 2z = -11, -2x + y + 2z = -3 ───');
+const Ab1 = [
+  [2,  1, -1,  8],
+  [-3, -1,  2, -11],
+  [-2,  1,  2, -3]
+];
+const { echelon: E1, log: log1 } = escalonar(Ab1);
+log1.forEach(l => console.log(' ', l));
+console.log('Forma escalonada:'); E1.forEach(r => console.log(' ', r.map(v => v.toFixed(4))));
+const sol1 = substituicao_retroativa(E1);
+console.log('Solução: x =', sol1[0].toFixed(4), 'y =', sol1[1].toFixed(4), 'z =', sol1[2].toFixed(4));
+console.log('Verificação math.lusolve:', math.lusolve([[2,1,-1],[-3,-1,2],[-2,1,2]],[8,-11,-3]).flat().map(v=>v.toFixed(4)));
+
+// ─── T2: Sistema SPI (segunda linha múltiplo da primeira) ─────────────────────
+
+console.log('\n─── T2: Sistema SPI ───');
+const Ab2 = [
+  [1, 2, 3],
+  [2, 4, 6]   // 2 * linha 1 → dependente
+];
+const { echelon: E2, log: log2 } = escalonar(Ab2);
+log2.forEach(l => console.log(' ', l));
+console.log('Forma escalonada:'); E2.forEach(r => console.log(' ', r));
+
+// variável livre: x2 = t
+console.log('Solução paramétrica: x1 = 3 - 2t, x2 = t (t livre)');
+[0, 1, 2].forEach(t => {
+  const x1 = 3 - 2*t, x2 = t;
+  console.log(`  t=${t}: x1=${x1}, x2=${x2} → verif: ${1*x1 + 2*x2} = 3 ✓`);
+});
+
+// ─── T3: Sistema SI (impossível) ─────────────────────────────────────────────
+
+console.log('\n─── T3: Sistema SI ───');
+const Ab3 = [
+  [1, 2, 3],
+  [1, 2, 5]   // mesmos coeficientes, b diferente → contradição
+];
+const { echelon: E3, log: log3 } = escalonar(Ab3);
+log3.forEach(l => console.log(' ', l));
+console.log('Forma escalonada:'); E3.forEach(r => console.log(' ', r));
+console.log('Linha [0, 0, 2] → 0 = 2: contradição, sistema impossível');
+console.log('Geometricamente: duas retas paralelas, nunca se intersectam');
+
+// ─── T4: classificar_sistema com Rouché-Capelli ───────────────────────────────
+
+function rank(matrix) {
+  const m = matrix.map(r => [...r]);
+  const rows = m.length, cols = m[0].length;
+  let r = 0;
+  for (let col = 0; col < cols && r < rows; col++) {
+    let pivot = -1;
+    for (let i = r; i < rows; i++) {
+      if (Math.abs(m[i][col]) > eps) { pivot = i; break; }
+    }
+    if (pivot === -1) continue;
+    [m[r], m[pivot]] = [m[pivot], m[r]];
+    for (let i = r + 1; i < rows; i++) {
+      const f = m[i][col] / m[r][col];
+      for (let j = col; j < cols; j++) m[i][j] -= f * m[r][j];
+    }
+    r++;
+  }
+  return r;
+}
+
+function classificar_sistema(A, b) {
+  const Ab = A.map((row, i) => [...row, b[i]]);
+  const rA = rank(A);
+  const rAb = rank(Ab);
+  const n = A[0].length;
+  if (rA !== rAb) return 'SI';
+  if (rA === n) return 'SPD';
+  return 'SPI';
+}
+
+console.log('\n─── T4: Classificação de sistemas ───');
+const sistemas = [
+  { A:[[2,1],[-1,3]], b:[5,4], esperado:'SPD' },
+  { A:[[1,2],[2,4]], b:[3,6], esperado:'SPI' },
+  { A:[[1,2],[2,4]], b:[3,7], esperado:'SI' },
+  { A:[[1,0,0],[0,1,0],[0,0,1]], b:[1,2,3], esperado:'SPD' },
+  { A:[[1,2,3],[4,5,6],[7,8,9]], b:[1,2,3], esperado:'SPI' }
+];
+sistemas.forEach(s => {
+  const res = classificar_sistema(s.A, s.b);
+  console.log(`Esperado: ${s.esperado} → Resultado: ${res}`);
+});
+
+// ─── T5: Solução paramétrica explícita ────────────────────────────────────────
+
+console.log('\n─── T5: Solução paramétrica ───');
+// x + 2y + z = 4
+// 2x + 4y + 2z = 8  (dependente)
+const A5 = [[1,2,1],[2,4,2]];
+const b5 = [4, 8];
+console.log('Sistema: x + 2y + z = 4 (com 3 incógnitas e 1 equação independente)');
+console.log('Variáveis livres: y=s, z=t');
+console.log('Solução geral: x = 4 - 2s - t, y = s, z = t');
+[[0,0],[1,0],[0,1],[1,1]].forEach(([s,t]) => {
+  const x = 4 - 2*s - t;
+  const check = x + 2*s + t;
+  console.log(`  s=${s}, t=${t}: x=${x} → verificação: ${check} = 4 ✓`);
+});
+
+// ─── T6: Comparação com solver built-in ───────────────────────────────────────
+
+console.log('\n─── T6: Comparação com math.lusolve ───');
+const A6 = [[3,1,-1],[1,4,2],[2,-1,5]];
+const b6 = [2, 7, 3];
+const { echelon: E6 } = escalonar(A6.map((r,i) => [...r, b6[i]]));
+const mySol = substituicao_retroativa(E6);
+const builtIn = math.lusolve(A6, b6).flat();
+console.log('Minha solução:', mySol.map(v=>v.toFixed(6)));
+console.log('math.lusolve:', builtIn.map(v=>v.toFixed(6)));
+
+try {
+  const Asing = [[1,2],[2,4]];
+  const bsing = [1,3];
+  math.lusolve(Asing, bsing);
+} catch(e) {
+  console.log('Solver com sistema singular:', e.message);
+}

--- a/assignments/submissions/40250178/04/reflexao.md
+++ b/assignments/submissions/40250178/04/reflexao.md
@@ -1,0 +1,9 @@
+# Reflexão A04
+
+O que ficou mais claro neste assignment foi a ligação entre o Teorema de Rouché-Capelli e a eliminação de Gauss. Na prática, depois de escalonar a matriz aumentada [A|b], basta contar as linhas não nulas de A e de [A|b] para saber o tipo de sistema — não é preciso calcular mais nada.
+
+A parte do sistema impossível foi a que fez mais sentido geometricamente: duas equações com os mesmos coeficientes mas segundos membros diferentes são duas retas paralelas. Nunca se cruzam, logo não há solução. Em 3D seria dois planos paralelos.
+
+A substituição retroativa também foi interessante de implementar — partimos da última linha (que já tem só uma incógnita) e vamos subindo, substituindo os valores já conhecidos. É exatamente o que fazemos à mão nos testes.
+
+Quanto à comparação com o math.lusolve: os resultados são iguais para sistemas SPD, mas o solver lança erro em sistemas singulares em vez de identificar o tipo — para isso é preciso a análise de rank.


### PR DESCRIPTION
## Submission Metadata
- Student number: 40250178
- Assignment code: A04
- Language track: `javascript`
- Submission folder path: `assignments/submissions/40250178/04/`

## Student Submission Checklist
- [x] This PR targets `develop`
- [x] Source branch follows `<student_number>-A<nn>`
- [x] PR title follows `Submission <student_number> --- A<nn>`
- [x] Assignment code is between `A01` and `A06`
- [x] All changed files are inside `assignments/submissions/<student>/<nn>/`
- [x] `README.md` exists in the submission folder
- [x] `reflexao.md` exists in the submission folder
- [x] Exactly one language track is present (`javascript/`, not both)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds A04 submission implementing a linear systems solver and classifier in JavaScript. Includes a CLI script using `mathjs` and an HTML page with 2D/3D visualizations.

- New Features
  - Gaussian elimination with partial pivoting and back-substitution, with step logs.
  - Rank-based classification (Rouché–Capelli) for SPD/SPI/SI and parametric solutions.
  - Worked examples and verification against `mathjs` lusolve; handles singular systems gracefully.
  - Plotly visualizations for 2D lines and 3D planes showing unique, infinite, and impossible cases.
  - README with run steps and a reflection write-up.

<sup>Written for commit 9340cbd7bf000763500eac853de9316d21418724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/linear-algebra-with-python/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

