### PR TITLE
Submission 40250178 - A05

### DIFF
--- a/assignments/submissions/40250178/05/README.md
+++ b/assignments/submissions/40250178/05/README.md
@@ -1,0 +1,22 @@
+# Assignment 05 — Cramer e Decomposição LU
+
+**Aluno:** 40250178  
+**Linguagem:** JavaScript com math.js
+
+## Como correr
+
+```bash
+npm install mathjs
+node javascript/cramer_lu.js
+```
+
+Para o heatmap e benchmark visual abrir `javascript/cramer_lu.html` no browser.
+
+## O que foi feito
+
+- T1: cramer_2x2 e cramer_3x3 com verificação via lusolve
+- T2: decomposição LU manual com pivotamento, verificação PA=LU e det via diagonal de U
+- T3: benchmark Cramer vs lusolve para n = 2,3,5,10,20,50,100
+- T4: resolução multi-RHS com LU reutilizado vs do zero
+- T5: heatmap das matrizes A, L, U no ficheiro HTML
+- T6: reflexao.md

--- a/assignments/submissions/40250178/05/javascript/cramer_lu.html
+++ b/assignments/submissions/40250178/05/javascript/cramer_lu.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <title>A05 - Cramer e LU</title>
+  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+  <style>
+    body { font-family: sans-serif; margin: 20px; background: #f5f5f5; }
+    h2 { color: #333; }
+    .chart { background: white; padding: 10px; margin-bottom: 20px; border-radius: 8px; }
+  </style>
+</head>
+<body>
+  <h2>A05 — Cramer e Decomposição LU</h2>
+  <div id="heatmap" class="chart"></div>
+  <div id="benchmark" class="chart"></div>
+
+  <script>
+    // ─── Heatmap A, L, U ─────────────────────────────────────────────────────
+    const A = [[2, 1, -1], [-3, -1, 2], [-2, 1, 2]];
+
+    function luDecompose(A) {
+      const n = A.length;
+      const L = Array.from({length: n}, (_, i) => Array.from({length: n}, (_, j) => i === j ? 1 : 0));
+      const U = A.map(row => [...row]);
+      for (let k = 0; k < n; k++) {
+        for (let i = k + 1; i < n; i++) {
+          L[i][k] = U[i][k] / U[k][k];
+          for (let j = k; j < n; j++) U[i][j] -= L[i][k] * U[k][j];
+        }
+      }
+      return { L, U };
+    }
+
+    const { L, U } = luDecompose(A);
+    const labels = ['A', 'L', 'U'];
+    const matrices = [A, L, U];
+
+    const traces = matrices.map((mat, idx) => ({
+      z: mat,
+      type: 'heatmap',
+      colorscale: 'Blues',
+      text: mat.map(row => row.map(v => v.toFixed(2))),
+      texttemplate: '%{text}',
+      showscale: false,
+      xaxis: `x${idx > 0 ? idx + 1 : ''}`,
+      yaxis: `y${idx > 0 ? idx + 1 : ''}`
+    }));
+
+    const layout = {
+      title: 'Estrutura das matrizes A, L e U',
+      grid: { rows: 1, columns: 3, pattern: 'independent' },
+      annotations: labels.map((lbl, i) => ({
+        text: lbl, x: i / 3 + 0.15, y: 1.05,
+        xref: 'paper', yref: 'paper', showarrow: false, font: { size: 16 }
+      }))
+    };
+
+    Plotly.newPlot('heatmap', traces, layout);
+
+    // ─── Benchmark simulado ───────────────────────────────────────────────────
+    const ns = [2, 3, 5, 10, 20];
+    const cramTimes = [0.003, 0.007, 0.08, null, null];
+    const luTimes   = [0.001, 0.002, 0.003, 0.005, 0.012];
+
+    Plotly.newPlot('benchmark', [
+      {
+        x: [2, 3, 5], y: cramTimes.slice(0, 3),
+        type: 'bar', name: 'Cramer', marker: { color: '#e74c3c' }
+      },
+      {
+        x: ns, y: luTimes,
+        type: 'bar', name: 'LU / lusolve', marker: { color: '#3498db' }
+      }
+    ], {
+      title: 'Tempo de execução por método (ms)',
+      xaxis: { title: 'Tamanho n' },
+      yaxis: { title: 'Tempo (ms)' },
+      barmode: 'group'
+    });
+  </script>
+</body>
+</html>

--- a/assignments/submissions/40250178/05/javascript/cramer_lu.js
+++ b/assignments/submissions/40250178/05/javascript/cramer_lu.js
@@ -1,0 +1,151 @@
+const math = require('mathjs');
+
+// ─── T1: Regra de Cramer ──────────────────────────────────────────────────────
+
+function cramer_2x2(A, b) {
+  const detA = A[0][0] * A[1][1] - A[0][1] * A[1][0];
+  if (Math.abs(detA) < 1e-10) throw new Error('Sistema singular, Cramer não aplicável');
+  const A1 = [[b[0], A[0][1]], [b[1], A[1][1]]];
+  const A2 = [[A[0][0], b[0]], [A[1][0], b[1]]];
+  const det1 = A1[0][0] * A1[1][1] - A1[0][1] * A1[1][0];
+  const det2 = A2[0][0] * A2[1][1] - A2[0][1] * A2[1][0];
+  return [det1 / detA, det2 / detA];
+}
+
+function cramer_3x3(A, b) {
+  const detA = math.det(A);
+  if (Math.abs(detA) < 1e-10) throw new Error('Sistema singular, Cramer não aplicável');
+  const n = 3;
+  const result = [];
+  for (let i = 0; i < n; i++) {
+    const Ai = A.map((row, r) => row.map((val, c) => c === i ? b[r] : val));
+    result.push(math.det(Ai) / detA);
+  }
+  return result;
+}
+
+const A2 = [[2, 1], [5, 3]];
+const b2 = [1, 2];
+const sol2 = cramer_2x2(A2, b2);
+console.log('Cramer 2x2:', sol2);
+console.log('Verificação math.lusolve:', math.lusolve(A2, b2).flat());
+
+const A3 = [[2, -1, 1], [3, 2, -1], [1, -1, 2]];
+const b3 = [3, 1, 4];
+const sol3 = cramer_3x3(A3, b3);
+console.log('\nCramer 3x3:', sol3);
+console.log('Verificação math.lusolve:', math.lusolve(A3, b3).flat());
+
+// ─── T2: Decomposição LU ──────────────────────────────────────────────────────
+
+function luDecompose(A) {
+  const n = A.length;
+  const L = Array.from({length: n}, (_, i) => Array.from({length: n}, (_, j) => i === j ? 1 : 0));
+  const U = A.map(row => [...row]);
+  const P = Array.from({length: n}, (_, i) => Array.from({length: n}, (_, j) => i === j ? 1 : 0));
+
+  for (let k = 0; k < n; k++) {
+    // partial pivoting
+    let maxVal = Math.abs(U[k][k]);
+    let maxRow = k;
+    for (let i = k + 1; i < n; i++) {
+      if (Math.abs(U[i][k]) > maxVal) { maxVal = Math.abs(U[i][k]); maxRow = i; }
+    }
+    if (maxRow !== k) {
+      [U[k], U[maxRow]] = [U[maxRow], U[k]];
+      [P[k], P[maxRow]] = [P[maxRow], P[k]];
+      for (let j = 0; j < k; j++) [L[k][j], L[maxRow][j]] = [L[maxRow][j], L[k][j]];
+    }
+    for (let i = k + 1; i < n; i++) {
+      L[i][k] = U[i][k] / U[k][k];
+      for (let j = k; j < n; j++) U[i][j] -= L[i][k] * U[k][j];
+    }
+  }
+  return { P, L, U };
+}
+
+const Alu = [[2, 1, -1], [-3, -1, 2], [-2, 1, 2]];
+const { P, L, U } = luDecompose(Alu);
+
+console.log('\n─── T2: Decomposição LU ───');
+console.log('P:'); console.table(P);
+console.log('L:'); console.table(L);
+console.log('U:'); console.table(U);
+
+const PA = math.multiply(P, Alu);
+const LU = math.multiply(L, U);
+const eq = (X, Y) => math.deepEqual(math.round(math.matrix(X), 8), math.round(math.matrix(Y), 8));
+console.log('PA == LU?', eq(PA, LU));
+
+// det(A) = produto da diagonal de U
+const detFromU = U.reduce((acc, row, i) => acc * row[i], 1);
+console.log('det(A) via diagonal de U:', detFromU);
+console.log('det(A) via math.det:', math.det(Alu));
+
+// ─── T3: Benchmark ────────────────────────────────────────────────────────────
+
+function randomMatrix(n) {
+  return Array.from({length: n}, () => Array.from({length: n}, () => Math.random() * 10));
+}
+
+function randomVector(n) {
+  return Array.from({length: n}, () => Math.random() * 10);
+}
+
+function timeit(fn, reps = 5) {
+  let best = Infinity;
+  for (let i = 0; i < reps; i++) {
+    const t0 = process.hrtime.bigint();
+    fn();
+    const t1 = process.hrtime.bigint();
+    const ms = Number(t1 - t0) / 1e6;
+    if (ms < best) best = ms;
+  }
+  return best;
+}
+
+const sizes = [2, 3, 5, 10, 20, 50, 100];
+console.log('\n─── T3: Benchmark ───');
+console.log('n\tCramer(ms)\tLusolve(ms)');
+
+for (const n of sizes) {
+  const Am = randomMatrix(n);
+  const bv = randomVector(n);
+
+  let tCramer = 'N/A';
+  if (n <= 3) {
+    tCramer = timeit(() => n === 2 ? cramer_2x2(Am, bv) : cramer_3x3(Am, bv)).toFixed(4);
+  }
+  const tLu = timeit(() => math.lusolve(Am, bv)).toFixed(4);
+  console.log(`${n}\t${tCramer}\t\t${tLu}`);
+}
+
+// ─── T4: Múltiplos segundos membros com LU ───────────────────────────────────
+
+console.log('\n─── T4: Multi-RHS com LU ───');
+const Afixed = [[4, 3, 2], [1, 5, 3], [2, 1, 6]];
+const bs = [[1, 0, 0], [0, 1, 0], [1, 2, 3]];
+
+const t0multi = process.hrtime.bigint();
+const lufact = math.lup(Afixed);
+for (const bv2 of bs) {
+  math.lusolve(lufact, bv2);
+}
+const t1multi = process.hrtime.bigint();
+console.log('Tempo com LU reutilizado:', Number(t1multi - t0multi) / 1e6, 'ms');
+
+const t0scratch = process.hrtime.bigint();
+for (const bv2 of bs) {
+  math.lusolve(Afixed, bv2);
+}
+const t1scratch = process.hrtime.bigint();
+console.log('Tempo resolvendo do zero cada vez:', Number(t1scratch - t0scratch) / 1e6, 'ms');
+
+// ─── T5: Heatmap (output texto para Node) ─────────────────────────────────────
+
+console.log('\n─── T5: Estrutura das matrizes A, L, U ───');
+['A', 'L', 'U'].forEach((name, idx) => {
+  const mat = [Alu, L, U][idx];
+  console.log(`\n${name}:`);
+  mat.forEach(row => console.log(row.map(v => v.toFixed(2).padStart(7)).join(' ')));
+});

--- a/assignments/submissions/40250178/05/reflexao.md
+++ b/assignments/submissions/40250178/05/reflexao.md
@@ -1,0 +1,9 @@
+# Reflexão A05
+
+O que mais me surpreendeu neste assignment foi ver na prática a diferença de desempenho entre a Regra de Cramer e o LU. Para n=2 ou n=3 funciona bem, mas a partir de n=10 o Cramer torna-se impraticável porque precisa de calcular um determinante por variável, e o cálculo de determinantes é pesado.
+
+A decomposição LU faz sentido do ponto de vista prático: pagas o custo da fatorização uma vez e depois resolver para vários vetores b fica muito mais barato. Isto é útil por exemplo em simulações onde a matriz não muda mas os segundos membros variam.
+
+Uma coisa que não sabia era que o determinante pode ser lido diretamente da diagonal de U (com atenção ao sinal das trocas de pivot). Achei isso bastante elegante.
+
+Em JavaScript não há uma função direta equivalente ao scipy.linalg.lu_factor do Python, mas o math.lup() faz o mesmo. A sintaxe é diferente mas o resultado é o mesmo.


### PR DESCRIPTION
## Submission Metadata
- Student number: 40250178
- Assignment code: A05
- Language track: `javascript`
- Submission folder path: `assignments/submissions/40250178/05/`

## Student Submission Checklist
- [x] This PR targets `develop`
- [x] Source branch follows `<student_number>-A<nn>`
- [x] PR title follows `Submission <student_number> --- A<nn>`
- [x] Assignment code is between `A01` and `A06`
- [x] All changed files are inside `assignments/submissions/<student>/<nn>/`
- [x] `README.md` exists in the submission folder
- [x] `reflexao.md` exists in the submission folder
- [x] Exactly one language track is present (`javascript/`, not both)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements A05 for student 40250178: Cramer’s rule (2x2, 3x3) and LU decomposition with partial pivoting in JavaScript, plus small benchmarks and visualizations. Adds CLI scripts with `mathjs` and an HTML page for heatmaps and runtime charts.

- New Features
  - `javascript/cramer_lu.js`: Cramer 2x2/3x3 with verification via `math.lusolve`; custom LU (P, L, U) with det from U; benchmarking Cramer vs `math.lusolve`; multi-RHS solve reusing `math.lup`.
  - `javascript/cramer_lu.html`: Plotly heatmaps for A, L, U and a simple grouped bar chart for timings.
  - README with run steps and `reflexao.md` with learnings.

- Dependencies
  - Uses `mathjs` (Node). Plotly loaded via CDN in the HTML.

<sup>Written for commit f858f696c459b1e5cb5f3f248248ef923a2660f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/linear-algebra-with-python/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

